### PR TITLE
Update to runtime 24.08

### DIFF
--- a/org.mmass.mMass.yaml
+++ b/org.mmass.mMass.yaml
@@ -1,6 +1,6 @@
 id: org.mmass.mMass
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: mmass
 finish-args:
@@ -96,8 +96,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/73/e1/88932bb0420a0fbe1547ee96d4e7332de5c1ed5a846a6c96ea422c6bf753/numpy-1.5.1.tar.gz
-        sha256: c36789ec381fec09f519249744ea36a77e5534b69446a59ee73b06cac29542eb
+        url: https://files.pythonhosted.org/packages/b7/6f/24647f014eef9b67a24adfcbcd4f4928349b4a0f8393b3d7fe648d4d2de3/numpy-1.16.6.zip
+        sha256: e5cf3fdf13401885e8eea8170624ec96225e2174eb0c611c6f26dd33b489e3ff
 
   - name: mmass
     buildsystem: simple


### PR DESCRIPTION
Also bumping https://pypi.org/project/numpy/1.16.6/ which is the latest version that still builds for Python 2.7